### PR TITLE
Bump elasticsearch client to 8.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const elasticsearchHost = process.env.ES_URL || 'http://elastic:changeme@localho
 const client = new Client({ node: elasticsearchHost })
 
 
-const port = process.env.PORT || 80;
+const port = process.env.PORT || 8080;
 const server = http.createServer(async function (request, response) {
 
     // Set CORS headers
@@ -56,8 +56,8 @@ const server = http.createServer(async function (request, response) {
                 zoom: parseInt(params.z),
                 x: parseInt(params.x),
                 y: parseInt(params.y),
-                body
-            });
+                ...body,
+            }, { meta: true });
 
             // set response header
             response.writeHead(tile.statusCode, {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const elasticsearchHost = process.env.ES_URL || 'http://elastic:changeme@localho
 const client = new Client({ node: elasticsearchHost })
 
 
-const port = process.env.PORT || 8080;
+const port = process.env.PORT || 80;
 const server = http.createServer(async function (request, response) {
 
     // Set CORS headers

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mvt_sample",
   "version": "0.0.1",
   "dependencies": {
-    "@elastic/elasticsearch": "^7.15.0",
+    "@elastic/elasticsearch": "^8.1.0",
     "request": "^2.88.2"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,11 @@ Run an [Elasticsearch](https://www.elastic.co/downloads/elasticsearch) instance.
 
 #### Run TMS server
 
-To start the TMS server, run the node script. `node` is included with the NodeJS runtime. It will start a server in `localhost` and `PORT` environment variable or `8080` by default.
+To start the TMS server, run the node script. `node` is included with the NodeJS runtime. It will start a server in `localhost` and `PORT` environment variable or `80` by default.
 
 > node ./index.js
 
 #### Demo page
 
-To view the web page, just open up `http://localhost:8080` or `http://localhost:{PORT}` browser.
+To view the web page, just open up `http://localhost:80` or `http://localhost:{PORT}` browser.
 


### PR DESCRIPTION
As suggested in [this Discuss post](https://discuss.elastic.co/t/vector-tile-api-updated-mvt-sample-error/303291) I've updated the elasticsearch client to the latest release (8.1.0). 

I also fixed a couple of breaking changes between 7.15.0 and 8.1.0 [[1](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html#_remove_the_body_key_from_the_request)] [[2](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html#_the_returned_value_of_api_calls_is_the_body_and_not_the_http_related_keys)]. 